### PR TITLE
updated assertion_filter_cond by adding gsub() argument to line 520 s…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ## Updates of Existing Functions
 
+* Updated `assertions_filter_cond` by adding a `gsub()` argument   on line 520 so that error messages return `filter_add` instead of  `enexpr(filter_add)`.
+
 * Error messaging throughout the package have been updated from `rlang::abort()` to `cli::cli_abort()`. As a part of the update, each of the `assert_*()` functions have new arguments `assert_*(message, arg_name, call, class).` (#367)
 
 * Warning messaging has also been updated to use `{cli}` messaging.

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -517,6 +517,8 @@ assert_filter_cond <- function(arg,
     return(invisible(arg))
   }
 
+  arg_name <- gsub("^.*\\((.*)\\)$", "\\1", arg_name)
+
   provided <- !is_missing(arg)
   if (provided && !(is_call(arg) || is_logical(arg))) {
     cli_abort(


### PR DESCRIPTION
…o that the error message returned for arg_name returns inputs wrapped in functionsby themselves without the function. So instead of expr(filter_add) in the error message its filter_add

Thank you for your Pull Request! We have developed this task checklist from the [Development Process Guide](https://pharmaverse.github.io/admiral/dev/CONTRIBUTING.html) to help with the final steps of the process. Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the admiral codebase remains robust and consistent.   

Please check off each taskbox as an acknowledgment that you completed the task or check off that it is not relevant to your Pull Request. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `main` branch until you have checked off each task.

- [ ] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [ ] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/). Run `styler::style_file()` to style R and Rmd files
- [ ] Updated relevant unit tests or have written new unit tests, which should consider realistic data scenarios and edge cases, e.g. empty datasets, errors, boundary cases etc. - See [Unit Test Guide](https://pharmaverse.github.io/admiraldev/articles/unit_test_guidance.html#tests-should-be-robust-to-cover-realistic-data-scenarios)
- [ ] If you removed/replaced any function and/or function parameters, did you fully follow the [deprecation guidance](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#deprecation)?
- [ ] Update to all relevant roxygen headers and examples, including keywords and families. Refer to the [categorization of functions](https://pharmaverse.github.io/admiraldev/articles/programming_strategy.html#categorization-of-functions) to tag appropriate keyword/family.
- [ ] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [ ] Address any updates needed for vignettes and/or templates
- [ ] Update `NEWS.md` under the header `# admiral (development version)` if the changes pertain to a user-facing function (i.e. it has an `@export` tag) or documentation aimed at users (rather than developers)
- [ ] Build admiral site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://pharmaverse.github.io/admiraldev/reference/index.html)" page. 
- [ ] Address or fix all lintr warnings and errors - `lintr::lint_package()`
- [ ] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [ ] Link the issue in the Development Section on the right hand side.
- [ ] Address all merge conflicts and resolve appropriately
- [ ] Pat yourself on the back for a job well done! Much love to your accomplishment!
