### PR TITLE
Set `insert-tweak-page-hook: false` for docs workflow

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -87,6 +87,8 @@ jobs:
       skip-multiversion-docs: true
       # Ref to use for the multiversion docs landing page
       multiversion-docs-landing-page: devel
+      # Do not insert the "tweak-page" hook
+      insert-tweak-page-hook: false
   linter:
     name: Lint
     uses: pharmaverse/admiralci/.github/workflows/lintr.yml@main


### PR DESCRIPTION
Following the fix from pharmaverse/admiralci#193, this ensures that the docs/pkgdown workflow gets fixed.
